### PR TITLE
A better filtering function

### DIFF
--- a/src/clique/core.clj
+++ b/src/clique/core.clj
@@ -181,6 +181,13 @@
        (map ns-dependencies)
        (reduce add-digraphs)))
 
+(defn restrict-to-source-nss
+  [dep-graph]
+  (let [source-nodes (map first (g/edges dep-graph))
+        source-nss   (set (map #(gattr/attr dep-graph % :ns) source-nodes))]
+    (ns-restrict dep-graph :include source-nss)))
+
+
 (def ^:dynamic default-exclude-re
   "Default namespaces to exclude from dependency graphs. Can be rebound."
   ["clojure\..*" "clojure.java" "System.*" ""])

--- a/src/clique/core.clj
+++ b/src/clique/core.clj
@@ -109,6 +109,14 @@
        (map fn-dep-graph)
        (apply add-digraphs)))
 
+
+(defn project-dependencies
+  "Returns a dependency graph of functions found in all namespaces within dir `src-dir`"
+  [src-dir]
+  (->> (find-namespaces-in-dir (file src-dir))
+       (map ns-dependencies)
+       (reduce add-digraphs)))
+
 ;; ## Filtering functions
 ;;
 ;; Here we have functions for filtering our dependency graphs by namespace.
@@ -174,12 +182,6 @@
         keep? (fn [ns] ((set included) (str ns)))]
     (g-attribute-filter dep-g :ns keep?)))
 
-(defn project-dependencies
-  "Returns a dependency graph of functions found in all namespaces within dir `src-dir`"
-  [src-dir]
-  (->> (find-namespaces-in-dir (file src-dir))
-       (map ns-dependencies)
-       (reduce add-digraphs)))
 
 (defn restrict-to-source-nss
   [dep-graph]


### PR DESCRIPTION
Filter to only source nodes in the arrow relations. This can be used in conjunction with `project-dependencies` to restrict graph to just those nodes in the project namespaces. (Or similarly with respect to `ns-namespaces`)
